### PR TITLE
更改保存电量时间为一小时，避免频繁写入flash

### DIFF
--- a/src/DC1.cpp
+++ b/src/DC1.cpp
@@ -658,7 +658,7 @@ void DC1::energyUpdate()
     {
         energyUpdateToday();
     }
-    if (perSecond % 301 == 0 && cse7766->Energy.kWhtoday > 0)
+    if (perSecond % 3600 == 0 && cse7766->Energy.kWhtoday > 0)
     {
         energySync();
         Config::saveConfig();


### PR DESCRIPTION
根据这个issue的讨论，提了个pull request: https://github.com/qlwz/esp_dc1/issues/16#issuecomment-1121838037